### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 rvm:
   - 2.1
+  
+sudo: false
+cache: bundler
 
 notifications:
   email:

--- a/spec/lib/import_export/deposit_type_exporter_spec.rb
+++ b/spec/lib/import_export/deposit_type_exporter_spec.rb
@@ -43,6 +43,8 @@ describe DepositTypeExporter do
   end
 
   it 'exports the deposit types to a csv file' do
+    DepositType.delete_all
+    
     pdf_name = 'PDF Document'
     pdf_agreement = 'Some agreement text for PDF deposits'
     pdf_license = 'A license for PDFs'
@@ -71,7 +73,7 @@ describe DepositTypeExporter do
   end
 
   def test_export_dir
-    timestamp = Time.now.strftime("%Y_%m_%d_%H%M%S")
+    timestamp = Time.now.strftime("%Y_%m_%d_%H%M%S%N")
     File.join(Rails.root, 'tmp', "export_test_#{timestamp}")
   end
 end

--- a/spec/lib/import_export/deposit_type_importer_spec.rb
+++ b/spec/lib/import_export/deposit_type_importer_spec.rb
@@ -27,10 +27,11 @@ describe DepositTypeImporter do
   end
 
   it 'imports CSV data' do
-    importer = DepositTypeImporter.new(test_import_file)
+    DepositType.delete_all
 
-    DepositType.count.should == 0
+    importer = DepositTypeImporter.new(test_import_file)
     importer.import_from_csv
+
     DepositType.count.should == 3
 
     pdf = DepositType.where(display_name: 'PDF Document').first
@@ -45,6 +46,7 @@ describe DepositTypeImporter do
   end
 
   it 'updates existing deposit types' do
+    DepositType.delete_all
     importer = DepositTypeImporter.new(test_import_file)
     pdf = FactoryGirl.create(:deposit_type, display_name: 'PDF Document', deposit_agreement: 'old text')
     DepositType.count.should == 1
@@ -56,7 +58,7 @@ describe DepositTypeImporter do
   end
 
   it 'doesnt create duplicate deposit types' do
-    DepositType.count.should == 0
+    DepositType.delete_all
     importer = DepositTypeImporter.new(File.join(fixture_path, 'import', 'deposit_types_with_duplicate_entries.csv'))
     importer.import_from_csv
 


### PR DESCRIPTION
Correct various issues in DepositType importer & exporter specs.  All result from database records not being cleaned up after tests - behavior which can't be duplicated on local systems, but seems pretty consistent in the Travis run logs.

There's probably a better solution, but the changes below address the key issues.

