### PR TITLE
Update workflow_status display

### DIFF
--- a/app/assets/stylesheets/catalog.css.scss
+++ b/app/assets/stylesheets/catalog.css.scss
@@ -36,12 +36,15 @@
   @extend .label;
   &.edited {
     @extend .label-warning;
+    &:after { content: 'edited';}
   }
-  &.new {
-    @extend .label-success;
+  &.unpublished {
+    @extend .label-info;
+    &:after { content: 'unpublished';}
   }
   &.published {
-    display: none;
+    @extend .label-success;
+    &:after { content: 'published';}
   }
 }
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -5,11 +5,10 @@ class SolrDocument
   include Tufts::SolrDocument
 
   def workflow_status
-    return unless draft? # Production objects don't have a workflow
     if published?
       :published
     elsif published_at.blank?
-      :new
+      :unpublished
     else
       :edited
     end

--- a/app/views/catalog/_index_header_default.html.erb
+++ b/app/views/catalog/_index_header_default.html.erb
@@ -17,6 +17,6 @@
   </h5>
 
   <div class="index-document-functions col-sm-3 col-lg-2">
-    <span class="<%= document.workflow_status %> workflow-status"><%= document.workflow_status %></span>
+    <span class="workflow-status <%= document.workflow_status %> col-md-12">&nbsp</span>
   </div>
 </div>

--- a/app/views/catalog/_show_header_default.html.erb
+++ b/app/views/catalog/_show_header_default.html.erb
@@ -1,1 +1,7 @@
-<h1 itemprop="name"><span class="<%= document.workflow_status %> workflow-status"><%= document.workflow_status %></span> <%= presenter(document).document_heading %></h1>
+<h1 itemprop="name"><%= presenter(document).document_heading %> </h1>
+<dl class="dl-horizontal  dl-invert">
+  <dt class="blacklight-id">Status:</dt>
+  <dd class="blacklight-id"><span class="workflow-status <%= document.workflow_status %>"> <%# need the space here %> </span></dd>
+</dl>
+
+

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -43,14 +43,14 @@ describe SolrDocument do
           it { is_expected.to eq :edited }
         end
         context "and published_at is not set" do
-          it { is_expected.to eq :new }
+          it { is_expected.to eq :unpublished } # you can reach this state from the unpublish method, so 'new' is misleading
         end
       end
     end
 
     context "when it is a production object" do
       let(:pid) { 'tufts:123' }
-      it { is_expected.to be_nil }
+      it { is_expected.to eq :published } # all production objects must have been published / should have 'published' as their workflow state
     end
   end
 

--- a/spec/views/catalog/index.html.erb_spec.rb
+++ b/spec/views/catalog/index.html.erb_spec.rb
@@ -79,10 +79,47 @@ describe 'catalog/index.html.erb' do
         @document_list = [SolrDocument.new(id: 'id2', has_model_ssim: ['fedora/cm:Image.4DS'])]
         render
       end
+
       it 'displays thumbnails' do
         src = download_path(@document_list.first.id, datastream_id: 'Thumbnail.png')
         expect(rendered).to have_selector("#documents .document-thumbnail img[src='#{src}']")
       end
     end
   end
+
+  context 'workflow_status' do
+    before do
+      allow(view).to receive(:has_search_parameters?) { true }
+    end
+
+    describe 'for drafts' do
+      before do
+        @earlier = "2015-01-01 12:00:00"
+        @later =  "2015-01-01 13:00:00"
+        @document_list = [SolrDocument.new(id: 'pub', active_fedora_model_ssi: 'TuftsImage', edited_at_dtsi: @earlier, published_at_dtsi: @earlier),
+                          SolrDocument.new(id: 'unpub', active_fedora_model_ssi: 'TuftsImage', edited_at_dtsi: @earlier, published_at_dtsi: nil),
+                          SolrDocument.new(id: 'ed', active_fedora_model_ssi: 'TuftsImage', edited_at_dtsi: @later, published_at_dtsi: @earlier)
+                          ]
+        render
+      end
+
+      it 'displays unpublished tags' do
+        expect(rendered).to have_selector(".unpublished", count: 1)
+      end
+      it 'displays published tags' do
+        expect(rendered).to have_selector(".published", count: 1)
+      end
+      it 'displays edited tags' do
+        expect(rendered).to have_selector(".edited", count: 1)
+      end
+    end
+
+    it 'handles production objects gracefully' do
+      @document_list = [SolrDocument.new(id: 'tufts:prod', has_model_ssim: ['fedora/cm:Image.4DS'])]
+      # These shouldn't end up in the document list from the catalog controller, but make sure the applications behaves reasonable if they do
+      render
+      expect(rendered).to have_selector(".published")
+    end
+  end
+
 end


### PR DESCRIPTION
Closes #459

* Changes "new" status to "unpublished" because existing items can enter this state after publication
* Moves display label to css for easier updates
* Shows label on all statuses (published, unpublished, edited) - change via css
* Shows "published" on any production (tufts:*) pids