### PR TITLE
Avoid invalid objects by refactoring form

### DIFF
--- a/app/views/records/choose_type.html.erb
+++ b/app/views/records/choose_type.html.erb
@@ -1,8 +1,13 @@
 <h1>Create a new record</h1>
 
-<%= bootstrap_form_tag url: hydra_editor.new_record_path, method: :get do |f| %>
-  <label class="control-label" for="type">Select an object type</label>
-  <%= select_tag :type, options_for_select(sorted_object_types) %>
+<%= bootstrap_form_tag url: hydra_editor.new_record_path, method: :get, html: { class: 'col-md-7' } do |f| %>
+  <%= f.form_group :type, id: 'type', label: { text: 'Select an object type' } do %>
+    <%= select_tag :type, options_for_select(sorted_object_types), class: 'form-control' %>
+  <% end %>
+  <%= f.text_field :title, required: true %>
+  <%= f.form_group :displays, id: 'displays', label: { text: 'Displays' } do %>
+    <%= select_tag :displays, options_for_select(displays_options), class: 'form-control' %>
+  <% end %>
   <%= f.text_field :pid, value: '', help: 'Leave blank for an auto-generated pid.' %>
 
   <%= f.primary 'Next'%>

--- a/spec/features/create_object_spec.rb
+++ b/spec/features/create_object_spec.rb
@@ -18,28 +18,33 @@ feature 'Admin user creates document' do
     click_link 'Create a new object'
 
     select "Audio", from: 'Select an object type'
+    fill_in 'Title', with: 'My title'
+    select 'dl', from: 'displays'
     fill_in 'Pid', with: pid
     click_button 'Next'
 
     # On the upload page
-    page.should have_selector('.file.btn', text: 'Upload ARCHIVAL_WAV')
-    page.should have_selector('input[type="file"].fileupload')
-    page.should have_selector('div.progress.progress-striped > .bar')
+    expect(page).to have_selector('.file.btn', text: 'Upload ARCHIVAL_WAV')
+    expect(page).to have_selector('input[type="file"].fileupload')
+    expect(page).to have_selector('div.progress.progress-striped > .bar')
     click_button 'Next'
 
     fill_in '*Title', with: 'My title'
     select('dl', from: 'Displays in Portal')
     click_button 'Save'
 
-    page.should have_selector('div.alert', text: 'Object was successfully updated.')
+    expect(page).to have_selector('div.alert', text: 'Object was successfully updated.')
   end
 
   scenario 'then purges it, recreates it, and it is properly marked Active in Fedora' do
+    #TODO this should probably be a controller test as it would have less overhead
     # First create object
     visit root_path
     click_link 'Create a new object'
 
     select "Audio", from: 'Select an object type'
+    fill_in 'Title', with: 'My title'
+    select 'dl', from: 'displays'
     fill_in 'Pid', with: pid
     click_button 'Next'
 
@@ -49,17 +54,19 @@ feature 'Admin user creates document' do
     select('dl', from: 'Displays in Portal')
     click_button 'Save'
 
-    page.should have_selector('div.alert', text: 'Object was successfully updated.')
+    expect(page).to have_selector('div.alert', text: 'Object was successfully updated.')
 
     # Now Purge it
     click_link 'Purge'
-    page.should have_selector('div.alert', text: '"My title to be purged" has been purged')
+    expect(page).to have_selector('div.alert', text: '"My title to be purged" has been purged')
 
     # Now create another object with the recycled identifier
     visit root_path
     click_link 'Create a new object'
 
     select "Audio", from: 'Select an object type'
+    fill_in 'Title', with: 'My title'
+    select 'dl', from: 'displays'
     fill_in 'Pid', with: pid
     click_button 'Next'
 
@@ -68,7 +75,7 @@ feature 'Admin user creates document' do
     fill_in '*Title', with: 'My title to be recreated'
     select('dl', from: 'Displays in Portal')
     click_button 'Save'
-    
+
     audio = TuftsAudio.find(draft_pid)
     expect(audio.state).to eq "A"
   end


### PR DESCRIPTION
Put the required fields on the first page. Fixes #461