### PR TITLE
shares only necessary tmp subdirectories

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,7 +23,7 @@ set :resque_kill_signal, "QUIT"
 set :linked_files, %w{config/initializers/devise.rb config/application.yml config/database.yml config/devise.yml config/fedora.yml config/resque-pool.yml config/redis.yml config/secrets.yml config/solr.yml}
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w{bin log tmp uploads vendor/bundle public/system}
+set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets uploads vendor/bundle public/system}
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
With exports going to #{object_store_root}/exports, revert to the previous approach to sharing tmp subdirectories.