### PR TITLE
Register Handle if the object isn't published

### DIFF
--- a/app/services/record_handle_service.rb
+++ b/app/services/record_handle_service.rb
@@ -1,0 +1,44 @@
+# This class is responsible for recording the provided handle on the draft
+# and the published object if it exists
+class RecordHandleService
+  def initialize(object, handle)
+    @object = object
+    @handle = handle
+  end
+
+  def run
+    record_handle_on_draft_version
+    record_handle_on_published_version
+  end
+
+  private
+    def record_handle_on_draft_version
+      record_handle(@object.find_draft)
+    end
+
+    # Handle the case where object is not published
+    def record_handle_on_published_version
+      record_handle(@object.find_published)
+    rescue ActiveFedora::ObjectNotFoundError
+    end
+
+    def record_handle(obj)
+      update_respecting_published_status(obj) do |item|
+        item.update_attributes(handle_attribute => [@handle])
+      end
+    end
+
+    def update_respecting_published_status(obj, &block)
+      if obj.published?
+        obj.publishing = true
+        yield obj
+        obj.publishing = false
+      else
+        yield obj
+      end
+    end
+
+    def handle_attribute
+      :identifier
+    end
+end

--- a/app/services/register_handle_service.rb
+++ b/app/services/register_handle_service.rb
@@ -9,7 +9,7 @@ class RegisterHandleService
     handle = generate_handle
     file_name = BatchFileGenerator.new(handle, url, key_path, password).generate
     if register_handle(file_name)
-      record_handle(handle)
+      RecordHandleService.new(object, handle).run
     else
       message = "Unable to register handle #{handle} for #{object.pid}\n#{messages}"
       HandleLogService.log(nil, object.pid, message)
@@ -59,27 +59,6 @@ class RegisterHandleService
       out
     end
 
-    def record_handle(handle)
-      [object.find_published, object.find_draft].each do |obj|
-        update_respecting_published_status(obj) do |item|
-          item.update_attributes(handle_attribute => [handle])
-        end
-      end
-    end
-
-    def update_respecting_published_status(obj, &block)
-      if obj.published?
-        obj.publishing = true
-        yield obj
-        obj.publishing = false
-      else
-        yield obj
-      end
-    end
-
-    def handle_attribute
-      :identifier
-    end
 
     def generate_handle
       "#{namespace}/#{sequence_number}"


### PR DESCRIPTION
previously it was raising an ActiveFedora::ObjectNotFound error
Fixes #496