### PR TITLE
Sort review by id

### DIFF
--- a/app/views/batches/_batch_actions.html.erb
+++ b/app/views/batches/_batch_actions.html.erb
@@ -1,7 +1,7 @@
   <div class="batch-actions">
       <% disabled = batch.status != :completed %>
 
-      <%= link_to 'Review Batch', catalog_index_path(search_field: 'batch', q: batch.id),
+      <%= link_to 'Review Batch', catalog_index_path(search_field: 'batch', q: batch.id, sort: 'id desc'),
         disabled: disabled,
         class: 'btn btn-primary' %>
 

--- a/spec/views/batches/_batch_actions.html.erb_spec.rb
+++ b/spec/views/batches/_batch_actions.html.erb_spec.rb
@@ -13,7 +13,8 @@ describe 'batches/_batch_actions.html.erb' do
     let(:batch_status) { :completed }
 
     it 'displays the form to operate on the batch' do
-      expect(rendered).to have_link('Review Batch', href: catalog_index_path(search_field: 'batch', q: batch.id.to_s))
+      # Must be sorted by ID, otherwise it will default to sorting by relevance, which will change as they review the batch.
+      expect(rendered).to have_link('Review Batch', href: catalog_index_path(search_field: 'batch', q: batch.id.to_s, sort: 'id desc'))
 
       #button to publish
       expect(rendered).to have_selector("form[method=post][action='#{batch_publishes_path}'] " +
@@ -45,7 +46,7 @@ describe 'batches/_batch_actions.html.erb' do
     it 'disables the batch operation buttons' do
       expect(rendered).to have_selector("input[type=submit][value='Publish Batch'][disabled=disabled]")
       expect(rendered).to have_selector("input[type=submit][value='Unpublish Batch'][disabled=disabled]")
-      expect(rendered).to have_selector("a[href='#{catalog_index_path(search_field: 'batch', q: batch.id.to_s)}'][disabled]", text: 'Review Batch')
+      expect(rendered).to have_selector("a[href='#{catalog_index_path(search_field: 'batch', q: batch.id.to_s, sort: 'id desc')}'][disabled]", text: 'Review Batch')
     end
   end
 end


### PR DESCRIPTION
this keeps the order consistent. if sort isn't provided then it sorts by
relevance which changes as you review items